### PR TITLE
Atoms/add task button

### DIFF
--- a/src/components/Atoms/AddTaskButton/index.jsx
+++ b/src/components/Atoms/AddTaskButton/index.jsx
@@ -1,25 +1,36 @@
 import React from "react";
 import styled from "styled-components";
 import plus from "../../../assets/svg/plus.svg";
+import COLOR from "../../../variables/color";
+import TEXT from "../../../variables/texts";
 
-const AddTaskButton = () => {
+const AddTaskButton = ({checked}) => {
   return (
-    <StyledButton>
+    <StyledAddButton onClick={checked}>
+      <HoverBack/>
       <Img src={plus} />
-      <StyledText>タスクを追加</StyledText>
-    </StyledButton>
+      <StyledAddText>タスクを追加</StyledAddText>
+    </StyledAddButton>
   );
 };
 export default AddTaskButton;
 
-//TODO:背景はhover時に出現するように
-const StyledButton = styled.button`
+const HoverBack = styled.div`
+  background-color: ${COLOR.GREEN};
+  opacity: 0;
+`;
+const StyledAddButton = styled.button`
+  display:flex;
   width: 126px;
   height: 24px;
-  padding: 2px;
+  padding: 2px 6px;
   border-radius: 12px;
-  background-color: ${COLOR.GREEN};
-  opacity: 0.2;
+  background-color:transparent;
+  border:none;
+  &:hover > ${HoverBack}{
+    opacity: 0.2;
+    cursor:pointer;
+  }
 `;
 
 const Img = styled.img`
@@ -27,11 +38,14 @@ const Img = styled.img`
   width: 20px;
   height: 20px;
   margin-right: 10px;
+  z-index:10;
 `;
 
-const StyledText = styled.div`
+const StyledAddText = styled.div`
   color: ${COLOR.GREEN};
-  ${SIZE.S};
+  ${TEXT.S}
+  z-index:10;
 `;
+
 
 //TODO:新しくstyleを付加するには

--- a/src/components/Atoms/AddTaskButton/index.jsx
+++ b/src/components/Atoms/AddTaskButton/index.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "styled-components";
+import plus from "../../../assets/svg/plus.svg";
+
+const AddTaskButton = () => {
+  return (
+    <StyledButton>
+      <Img src={plus} />
+      <StyledText>タスクを追加</StyledText>
+    </StyledButton>
+  );
+};
+export default AddTaskButton;
+
+//TODO:背景はhover時に出現するように
+const StyledButton = styled.button`
+  width: 126px;
+  height: 24px;
+  padding: 2px;
+  border-radius: 12px;
+  background-color: ${COLOR.GREEN};
+  opacity: 0.2;
+`;
+
+const Img = styled.img`
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  margin-right: 10px;
+`;
+
+const StyledText = styled.div`
+  color: ${COLOR.GREEN};
+  ${SIZE.S};
+`;
+
+//TODO:新しくstyleを付加するには

--- a/src/components/Atoms/AddTaskButton/index.jsx
+++ b/src/components/Atoms/AddTaskButton/index.jsx
@@ -7,7 +7,6 @@ import TEXT from "../../../variables/texts";
 const AddTaskButton = ({checked}) => {
   return (
     <StyledAddButton onClick={checked}>
-      <HoverBack/>
       <Img src={plus} />
       <StyledAddText>タスクを追加</StyledAddText>
     </StyledAddButton>
@@ -15,10 +14,6 @@ const AddTaskButton = ({checked}) => {
 };
 export default AddTaskButton;
 
-const HoverBack = styled.div`
-  background-color: ${COLOR.GREEN};
-  opacity: 0;
-`;
 const StyledAddButton = styled.button`
   display:flex;
   width: 126px;
@@ -27,8 +22,9 @@ const StyledAddButton = styled.button`
   border-radius: 12px;
   background-color:transparent;
   border:none;
-  &:hover > ${HoverBack}{
-    opacity: 0.2;
+  transition:0.2s;
+  &:hover{
+    background-color:rgba(70, 163, 129, 0.2);
     cursor:pointer;
   }
 `;
@@ -38,14 +34,9 @@ const Img = styled.img`
   width: 20px;
   height: 20px;
   margin-right: 10px;
-  z-index:10;
 `;
 
 const StyledAddText = styled.div`
   color: ${COLOR.GREEN};
   ${TEXT.S}
-  z-index:10;
 `;
-
-
-//TODO:新しくstyleを付加するには

--- a/src/components/Atoms/AddTaskButton/story.jsx
+++ b/src/components/Atoms/AddTaskButton/story.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Component from "./index";
+
+export default {
+  component: Component,
+  title: "Atoms/AddTaskButton",
+  parameters: {
+    backgrounds: {
+      default: "dark",
+    },
+  },
+};
+
+const Template = (args) => <Component {...args} />;
+
+export const Default = Template.bind({});

--- a/src/components/Atoms/AddTaskButton/story.jsx
+++ b/src/components/Atoms/AddTaskButton/story.jsx
@@ -14,3 +14,6 @@ export default {
 const Template = (args) => <Component {...args} />;
 
 export const Default = Template.bind({});
+Default.args = {
+  checked: () => console.log("clicked"),
+};


### PR DESCRIPTION
hover時の背景を表示させる際に、background-colorとopacityを併用してしまうと、文字やplusアイコンにもopacityが適用されてしまうので、無理やりrgba表示に変更しました。これ以外の解決策があれば教えていただきたいです...！